### PR TITLE
Introduce Nunjucks components

### DIFF
--- a/src/_includes/BoardItem.njk
+++ b/src/_includes/BoardItem.njk
@@ -1,0 +1,15 @@
+{% macro boardItem(name, status, image) %}
+    {% set status_class = 'status-' + status %}
+    {% set status_label = status | replace('_', ' ') | capitalize %}
+    <div class="board-item">
+        {% if image %}
+        <div class="board-image">
+            <img src="{{ image }}" alt="{{ name }}">
+        </div>
+        {% endif %}
+        <div class="board-details">
+            <span class="board-name">{{ name }}</span>
+            <span class="status-badge {{ status_class }}">{{ status_label }}</span>
+        </div>
+    </div>
+{% endmacro %}

--- a/src/_includes/FeatureCard.njk
+++ b/src/_includes/FeatureCard.njk
@@ -1,0 +1,14 @@
+{% macro featureCard(title, text, icon) %}
+    {% set icon_filename = icon or title | lower | replace(' ', '-') %}
+    <div class="feature-card">
+        {% if icon_filename %}
+        <div class="feature-icon">
+            <object data="/assets/icons/{{ icon_filename }}.svg" type="image/svg+xml" width="48" height="48" aria-label="{{ title }} icon">
+                <img src="/assets/icons/{{ icon_filename }}.svg" alt="{{ title }}" width="48" height="48">
+            </object>
+        </div>
+        {% endif %}
+        <h3>{{ title }}</h3>
+        <p>{{ text }}</p>
+    </div>
+{% endmacro %}

--- a/src/_includes/ReleaseTable.njk
+++ b/src/_includes/ReleaseTable.njk
@@ -1,0 +1,35 @@
+{% macro releaseTable(releases) %}
+    {% if releases %}
+    <table class="release-table">
+        <thead>
+            <tr>
+                <th>Version</th>
+                <th>Codename</th>
+                <th>Status</th>
+                <th>Date/Target</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% if releases.upcoming %}
+            <tr class="release-upcoming">
+                <td>{{ releases.upcoming.version }}</td>
+                <td>{{ releases.upcoming.codename }}</td>
+                <td>{{ releases.upcoming.status }}</td>
+                <td>{{ releases.upcoming.target_date }}</td>
+                <td>{{ releases.upcoming.description }}</td>
+            </tr>
+            {% endif %}
+            {% for rel in releases.items %}
+            <tr>
+                <td>{{ rel.version }}</td>
+                <td>{{ rel.codename }}</td>
+                <td>Released</td>
+                <td>{{ rel.date }}</td>
+                <td>{{ rel.description }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+{% endmacro %}

--- a/src/boards.md
+++ b/src/boards.md
@@ -2,7 +2,10 @@
 layout: base.njk
 title: "Supported Boards"
 description: "Hardware platforms validated and supported by Canopy firmware with feature matrix and validation status."
+templateEngineOverride: njk,md
 ---
+
+{% from "BoardItem.njk" import boardItem %}
 
 <div class="content-page">
 
@@ -37,7 +40,7 @@ The following boards are currently supported by Canopy firmware:
                 <td class="validation-status">
                     {%- if board.validation.status == "validated" -%}
                     <span class="status-validated">✓ Validated</span>
-                    {%- elsif board.validation.status == "in_progress" -%}
+                    {%- elif board.validation.status == "in_progress" -%}
                     <span class="status-in-progress">⏳ In Progress</span>
                     {%- else -%}
                     <span class="status-pending">⏸ Pending</span>
@@ -49,7 +52,7 @@ The following boards are currently supported by Canopy firmware:
                        target="_blank" 
                        rel="noopener"
                        class="commit-link">
-                        <code>{{ board.validation.commit | slice: 0, 7 }}</code>
+                        <code>{{ board.validation.commit | slice(0, 7) }}</code>
                     </a>
                 </td>
             </tr>
@@ -68,10 +71,10 @@ Pre-built firmware binaries are automatically generated for all validated boards
     {%- for board in boards.boards -%}
     {%- if board.validation.status == "validated" -%}
     <div class="download-card">
-        <h4>{{ board.name }}</h4>
+        {{ boardItem(board.name, board.validation.status) }}
         <p class="board-model">{{ board.model }}</p>
         <div class="download-links">
-            <a href="https://github.com/canopybmc/openbmc/releases/latest/download/{{ board.model | downcase | replace: " ", "-" }}-firmware.bin" 
+            <a href="https://github.com/canopybmc/openbmc/releases/latest/download/{{ board.model | lower | replace(" ", "-") }}-firmware.bin"
                class="download-btn"
                target="_blank" 
                rel="noopener">
@@ -82,7 +85,7 @@ Pre-built firmware binaries are automatically generated for all validated boards
             <small>
                 Validated: {{ board.validation.date }} |
                 <a href="{{ boards.github_repo }}/commit/{{ board.validation.commit }}" target="_blank" rel="noopener">
-                    Commit {{ board.validation.commit | slice: 0, 7 }}
+                    Commit {{ board.validation.commit | slice(0, 7) }}
                 </a>
             </small>
         </p>

--- a/src/index.md
+++ b/src/index.md
@@ -2,7 +2,10 @@
 layout: base.njk
 title: "Open Firmware, Open Future"
 description: "Canopy is an open-source firmware platform focused on security, transparency, and developer experience."
+templateEngineOverride: njk,md
 ---
+
+{% from "FeatureCard.njk" import featureCard %}
 
 <section class="hero">
     <div class="hero-container">
@@ -40,18 +43,7 @@ description: "Canopy is an open-source firmware platform focused on security, tr
         <h2 class="section-title">{{ features.title }}</h2>
         <div class="features-grid">
             {%- for feature in features.items -%}
-            <div class="feature-card">
-                <div class="feature-icon">
-                    {%- assign icon_filename = feature.title | downcase | replace: " ", "-" -%}
-                    <object data="/assets/icons/{{ icon_filename }}.svg" type="image/svg+xml" width="48" height="48" aria-label="{{ feature.title }} icon">
-                        <img src="/assets/icons/{{ icon_filename }}.svg" alt="{{ feature.title }}" width="48" height="48">
-                    </object>
-                </div>
-                <h3>{{ feature.title }}</h3>
-                <p>
-                    {{ feature.description }}
-                </p>
-            </div>
+            {{ featureCard(feature.title, feature.description) }}
             {%- endfor -%}
         </div>
     </div>

--- a/src/releases.md
+++ b/src/releases.md
@@ -2,11 +2,16 @@
 layout: base.njk
 title: "Releases"
 description: "Download the latest Canopy firmware releases and view release notes for all versions."
+templateEngineOverride: njk,md
 ---
+
+{% from "ReleaseTable.njk" import releaseTable %}
 
 <div class="content-page">
 
 # Releases
+
+{{ releaseTable(releases) }}
 
 <div class="releases-notice">
     <div class="notice-icon">


### PR DESCRIPTION
## Summary
- add `FeatureCard`, `BoardItem` and `ReleaseTable` macros
- convert pages to use new components
- switch markdown pages to Nunjucks engine
- update board download links to use Nunjucks filters

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885cfbff8548323b1b5a634124828b2