### PR TITLE
Add OCP APAC Summit to event banner

### DIFF
--- a/src/_data/conferences.json
+++ b/src/_data/conferences.json
@@ -30,6 +30,16 @@
     "url": "https://www.hpe.com/discover"
   },
   {
+    "name": "OCP APAC Summit",
+    "date_start": "2026-08-11",
+    "date_end": "2026-08-12",
+    "location": "TaiNEX 2",
+    "city": "Taipei City",
+    "country": "Taiwan",
+    "booth": "Booth PL07",
+    "url": "https://www.opencompute.org/summit/2026-ocp-apac-summit"
+  },
+  {
     "name": "OCP Global Summit",
     "date_start": "2026-10-12",
     "date_end": "2026-10-15",


### PR DESCRIPTION
## Summary

Updates the homepage "Canopy on Tour" event banner to feature the **OCP APAC Summit** as the next upcoming event.

The banner is data-driven: it auto-selects the earliest upcoming conference from `src/_data/conferences.json`. Adding OCP APAC (Aug 11–12) ahead of the OCP Global Summit (Oct 12) makes it the next event shown.

## Details added

- **OCP APAC Summit**
- 📅 Aug 11–12, 2026
- 📍 TaiNEX 2, Taipei City, Taiwan
- 🏢 Booth PL07
- 🔗 https://www.opencompute.org/summit/2026-ocp-apac-summit

## Testing

- `npm run build` succeeds
- Verified the rendered `_site/index.html` shows the OCP APAC Summit banner with date, location, and booth

https://claude.ai/code/session_01442qwxULRn1afPLVZNXD5U